### PR TITLE
bugfix: fixed caclulation of downsampling fraction for high-coverage …

### DIFF
--- a/modules/Genotypes.py
+++ b/modules/Genotypes.py
@@ -34,7 +34,7 @@ def RAF2genotypeProb(RAF):
 def downsample(baseqs):
     '''Randomly downsample so that floats do not get reduced to 0.0'''
     if len(baseqs) > 450:
-        x = 450 / len(baseqs)
+        x = float(450) / len(baseqs)
         return random.sample(baseqs, int(x*len(baseqs)))
     return baseqs
 


### PR DESCRIPTION
When Conpair is genotyping markers, it downsamples sites with coverage above 450X to make the likelihood math work. Conpair is written in python2, which always rounds down when dividing two integers. In this case, that meant that the downsampling fraction was always computed as 0. This code rarely, if ever, will get triggered for WGS, and probably won't make a huge difference for typical WES. The edge case that brought this to light was an exome sample with >1000X coverage. 

When the downsampling fraction is set to 0, and 0 reads are used, each possible genotype has the same likelihood, and the population AF priors dictate which genotype is called. When enough sites are above the coverage threshold, this will make two samples look discordant when they're actually concordant.  

The fix is to just force python to do float division. 